### PR TITLE
增加命令行设置配置参数

### DIFF
--- a/configo.go
+++ b/configo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/shafreeck/toml"
 	"github.com/shafreeck/toml/ast"
 
+	"flag"
 	"fmt"
 	goast "go/ast"
 	"reflect"
@@ -274,7 +275,7 @@ func Unmarshal(data []byte, v interface{}) error {
 	}
 
 	// apply flag param
-	ApplyFlags(v)
+	ApplyFlags(flag.CommandLine, v)
 	return nil
 }
 

--- a/configo.go
+++ b/configo.go
@@ -272,6 +272,9 @@ func Unmarshal(data []byte, v interface{}) error {
 	if err := applyDefault(reflect.ValueOf(v), false); err != nil {
 		return err
 	}
+
+	// apply flag param
+	ApplyFlags(v)
 	return nil
 }
 

--- a/example/conf/example.toml
+++ b/example/conf/example.toml
@@ -10,10 +10,10 @@
 #default:     10000
 #max-connection = 10000
 
-[redis]
+#[redis]
 
 #type:        []string
 #rules:       dialstring
 #description: The addresses of redis cluster
 #required
-cluster = []
+#cluster = []

--- a/example/flag.go
+++ b/example/flag.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"github.com/distributedio/configo"
+	"github.com/distributedio/configo/example/conf"
+)
+
+func main() {
+	c := &conf.Config{}
+
+	configo.Flags(c, "listen", "redis", "redis.0.cluster")
+	flag.Parse()
+
+	data, err := ioutil.ReadFile("conf/example.toml")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	err = configo.Unmarshal(data, c)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	fmt.Printf("%#v\n", c)
+}

--- a/example/flags.go
+++ b/example/flags.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	c := &conf.Config{}
 
-	configo.Flags(c, "listen", "redis", "redis.0.cluster")
+	configo.AddFlags(c, "listen", "redis", "redis.0.cluster")
 	flag.Parse()
 
 	data, err := ioutil.ReadFile("conf/example.toml")

--- a/example/flags.go
+++ b/example/flags.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	c := &conf.Config{}
 
-	configo.AddFlags(c, "listen", "redis", "redis.0.cluster")
+	configo.AddFlags(flag.CommandLine, c, "listen", "redis", "redis.0.cluster")
 	flag.Parse()
 
 	data, err := ioutil.ReadFile("conf/example.toml")

--- a/flags.go
+++ b/flags.go
@@ -1,10 +1,16 @@
 package configo
 
 import (
+	"flag"
+	"log"
 	"reflect"
+	"strconv"
+	"time"
 
 	"github.com/shafreeck/toml"
 )
+
+var flagMap = make(map[string]struct{})
 
 // Flags 将类中的变量加入到flags中，从而可以通过命令行进行设置
 // 可以通过keys指定范围的成员加入到flags中，如果不指定则将所有的
@@ -14,18 +20,60 @@ import (
 // 2. 多级变量：使用 root.child 的形式作为变量名称
 // 3. 数组变量：数组下标作为一个层级，例如要设置root[0].key, 则flags中的key名称为root.0.key
 func Flags(obj interface{}, keys ...string) {
-	m := make(map[string]struct{})
 	for i := range keys {
-		m[keys[i]] = struct{}{}
+		flagMap[keys[i]] = struct{}{}
 	}
-	t := NewTravel(func(path string, tag *toml.CfgTag, v reflect.Value) {
-		if _, ok := m[path]; len(m) > 0 && !ok {
+	t := NewTravel(func(path string, tag *toml.CfgTag, fv reflect.Value) {
+		if _, ok := flagMap[path]; len(flagMap) > 0 && !ok {
 			return
 		}
-		switch v.Kind() {
-		case reflect.Int:
-			//flags.Int(path, i, des)
+		var err error
+		//Set the default value
+		switch fv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16,
+			reflect.Int32, reflect.Int64:
+			var v int64
+			if v, err = strconv.ParseInt(tag.Value, 10, 64); err != nil {
+				if fv.Kind() == reflect.Int64 {
+					//try to parse a time.Duration
+					if d, err := time.ParseDuration(tag.Value); err == nil {
+						flag.Duration(path, time.Duration(d), tag.Description)
+						return
+					}
+				}
+				log.Fatalln(err)
+				return
+			}
+			flag.Int64(path, v, tag.Description)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16,
+			reflect.Uint32, reflect.Uint64:
+			var v uint64
+			if v, err = strconv.ParseUint(tag.Value, 10, 64); err != nil {
+				log.Fatalln(err)
+				return
+			}
+			flag.Uint64(path, v, tag.Description)
+		case reflect.Float32, reflect.Float64:
+			var v float64
+			if v, err = strconv.ParseFloat(tag.Value, 64); err != nil {
+				log.Fatalln(err)
+				return
+			}
+			flag.Float64(path, v, tag.Description)
+		case reflect.Bool:
+			var v bool
+			if v, err = strconv.ParseBool(tag.Value); err != nil {
+				log.Fatalln(err)
+				return
+			}
+			flag.Bool(path, v, tag.Description)
+		case reflect.String:
+			flag.String(path, tag.Value, tag.Description)
+		case reflect.Slice, reflect.Array:
+			// set as string type
+			flag.String(path, tag.Value, tag.Description)
 		default:
+			log.Fatalf("unsupport type %s for set flag", fv.Type())
 		}
 	})
 	t.Travel(obj)
@@ -37,29 +85,73 @@ func Flags(obj interface{}, keys ...string) {
 }
 
 func ApplyFlags(obj interface{}) {
-	/*
-		actualFlags := make(map[string]bool)
-		flag.Visit(func(f *flag.Flag) {
-			actualFlags[f.Name] = f
-		})
-		if len(actualFlags) == 0 {
+	actualFlags := make(map[string]*flag.Flag)
+	flag.Visit(func(f *flag.Flag) {
+		actualFlags[f.Name] = f
+	})
+	if len(actualFlags) == 0 {
+		return
+	}
+	t := NewTravel(func(path string, tag *toml.CfgTag, fv reflect.Value) {
+		f, ok := actualFlags[path]
+		if !ok {
 			return
 		}
-		t := newTravel(func(path string, v reflect.Value) {
-			if _, ok := actualFlags[path]; !ok {
+		if _, ok := flagMap[path]; len(flagMap) > 0 && !ok {
+			return
+		}
+		var err error
+		switch fv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16,
+			reflect.Int32, reflect.Int64:
+			var v int64
+			if v, err = strconv.ParseInt(f.Value.String(), 10, 64); err != nil {
+				if fv.Kind() == reflect.Int64 {
+					//try to parse a time.Duration
+					if d, err := time.ParseDuration(f.Value.String()); err == nil {
+						fv.SetInt(int64(d))
+						return
+					}
+				}
+				log.Fatalln(err)
 				return
 			}
-
-			if len(keys) > 0 && !match(path, keys) {
+			fv.SetInt(v)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16,
+			reflect.Uint32, reflect.Uint64:
+			var v uint64
+			if v, err = strconv.ParseUint(f.Value.String(), 10, 64); err != nil {
+				log.Fatalln(err)
 				return
 			}
-			switch v.Kind() {
-			case Int:
-				value := flags.IntVal()
-				addtomap
-			default:
+			fv.SetUint(v)
+		case reflect.Float32, reflect.Float64:
+			var v float64
+			if v, err = strconv.ParseFloat(f.Value.String(), 64); err != nil {
+				log.Fatalln(err)
+				return
 			}
-		})
-		t.travel(obj)
-	*/
+			fv.SetFloat(v)
+		case reflect.Bool:
+			var v bool
+			if v, err = strconv.ParseBool(f.Value.String()); err != nil {
+				log.Fatalln(err)
+				return
+			}
+			fv.SetBool(v)
+		case reflect.String:
+			fv.SetString(f.Value.String())
+		case reflect.Slice, reflect.Array:
+			// FIXME TODO
+			/*
+				v := rv.Addr().Interface()
+				if err := unmarshalArray(ft.Name, f.Value.String(), v); err != nil {
+					return err
+				}
+			*/
+		default:
+			log.Fatalf("unsupport type %s for set flag", fv.Type())
+		}
+	})
+	t.Travel(obj)
 }

--- a/flags.go
+++ b/flags.go
@@ -86,14 +86,14 @@ func AddFlags(fs *flag.FlagSet, obj interface{}, keys ...string) {
 				if fv.Kind() == reflect.Int64 {
 					//try to parse a time.Duration
 					if d, err := time.ParseDuration(tag.Value); err == nil {
-						fs.Duration(path, time.Duration(d), tag.Description+ConfigoFlagSuffix)
+						fs.Duration(path, time.Duration(d), ConfigoFlagSuffix+tag.Description)
 						return
 					}
 				}
 				log.Fatalln(err)
 				return
 			}
-			fs.Int64(path, v, tag.Description+ConfigoFlagSuffix)
+			fs.Int64(path, v, ConfigoFlagSuffix+tag.Description)
 		case reflect.Uint, reflect.Uint8, reflect.Uint16,
 			reflect.Uint32, reflect.Uint64:
 			var v uint64
@@ -101,26 +101,26 @@ func AddFlags(fs *flag.FlagSet, obj interface{}, keys ...string) {
 				log.Fatalln(err)
 				return
 			}
-			fs.Uint64(path, v, tag.Description+ConfigoFlagSuffix)
+			fs.Uint64(path, v, ConfigoFlagSuffix+tag.Description)
 		case reflect.Float32, reflect.Float64:
 			var v float64
 			if v, err = strconv.ParseFloat(tag.Value, 64); err != nil {
 				log.Fatalln(err)
 				return
 			}
-			fs.Float64(path, v, tag.Description+ConfigoFlagSuffix)
+			fs.Float64(path, v, ConfigoFlagSuffix+tag.Description)
 		case reflect.Bool:
 			var v bool
 			if v, err = strconv.ParseBool(tag.Value); err != nil {
 				log.Fatalln(err)
 				return
 			}
-			fs.Bool(path, v, tag.Description+ConfigoFlagSuffix)
+			fs.Bool(path, v, ConfigoFlagSuffix+tag.Description)
 		case reflect.String:
-			fs.String(path, tag.Value, tag.Description+ConfigoFlagSuffix)
+			fs.String(path, tag.Value, ConfigoFlagSuffix+tag.Description)
 		case reflect.Slice, reflect.Array:
 			// TODO 使用flag.Var设置变量
-			fs.String(path, tag.Value, tag.Description+ConfigoFlagSuffix)
+			fs.String(path, tag.Value, ConfigoFlagSuffix+tag.Description)
 		default:
 			log.Printf("unknow type %s for set flag", fv.Type())
 		}

--- a/flags.go
+++ b/flags.go
@@ -1,5 +1,11 @@
 package configo
 
+import (
+	"reflect"
+
+	"github.com/shafreeck/toml"
+)
+
 // Flags 将类中的变量加入到flags中，从而可以通过命令行进行设置
 // 可以通过keys指定范围的成员加入到flags中，如果不指定则将所有的
 // 变量都加入到flags中
@@ -8,20 +14,21 @@ package configo
 // 2. 多级变量：使用 root.child 的形式作为变量名称
 // 3. 数组变量：数组下标作为一个层级，例如要设置root[0].key, 则flags中的key名称为root.0.key
 func Flags(obj interface{}, keys ...string) {
-	/*
-		t := newTravel(func(path string, v reflect.Value) {
-			if len(keys) > 0 && !match(path, keys) {
-				return
-			}
-			switch v.Kind() {
-			case Int:
-				value := flags.IntVal()
-				addtomap
-			default:
-			}
-		})
-		t.travel(obj)
-	*/
+	m := make(map[string]struct{})
+	for i := range keys {
+		m[keys[i]] = struct{}{}
+	}
+	t := NewTravel(func(path string, tag *toml.CfgTag, v reflect.Value) {
+		if _, ok := m[path]; len(m) > 0 && !ok {
+			return
+		}
+		switch v.Kind() {
+		case reflect.Int:
+			//flags.Int(path, i, des)
+		default:
+		}
+	})
+	t.Travel(obj)
 
 	// 1. 遍历所有变量
 	// 2. 如果keys没有设置，则默认是将所有的变量都加入到flags中

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,58 @@
+package configo
+
+// Flags 将类中的变量加入到flags中，从而可以通过命令行进行设置
+// 可以通过keys指定范围的成员加入到flags中，如果不指定则将所有的
+// 变量都加入到flags中
+// 不同类型变量的书写规则
+// 1. 一级变量，即只有一层变量
+// 2. 多级变量：使用 root.child 的形式作为变量名称
+// 3. 数组变量：数组下标作为一个层级，例如要设置root[0].key, 则flags中的key名称为root.0.key
+func Flags(obj interface{}, keys ...string) {
+	/*
+		t := newTravel(func(path string, v reflect.Value) {
+			if len(keys) > 0 && !match(path, keys) {
+				return
+			}
+			switch v.Kind() {
+			case Int:
+				value := flags.IntVal()
+				addtomap
+			default:
+			}
+		})
+		t.travel(obj)
+	*/
+
+	// 1. 遍历所有变量
+	// 2. 如果keys没有设置，则默认是将所有的变量都加入到flags中
+	// 3. 如果指定了具体的变量名称，则只加入指定的变量到flags中
+	// 4. 在读取配置文件之后，添加完默认配置之后，应用命令行中的配置
+}
+
+func ApplyFlags(obj interface{}) {
+	/*
+		actualFlags := make(map[string]bool)
+		flag.Visit(func(f *flag.Flag) {
+			actualFlags[f.Name] = f
+		})
+		if len(actualFlags) == 0 {
+			return
+		}
+		t := newTravel(func(path string, v reflect.Value) {
+			if _, ok := actualFlags[path]; !ok {
+				return
+			}
+
+			if len(keys) > 0 && !match(path, keys) {
+				return
+			}
+			switch v.Kind() {
+			case Int:
+				value := flags.IntVal()
+				addtomap
+			default:
+			}
+		})
+		t.travel(obj)
+	*/
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/shafreeck/toml v0.0.0-20190326060449-44ad86712acc
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a // indirect
 	golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53 // indirect
 	golang.org/x/sys v0.0.0-20190318195719-6c81ef8f67ca // indirect

--- a/travel.go
+++ b/travel.go
@@ -22,12 +22,14 @@ func (t *Travel) Travel(obj interface{}) {
 func (t *Travel) travel(path string, v reflect.Value) {
 	switch v.Kind() {
 	case reflect.Ptr:
+		fmt.Printf("travel ptr")
 		vValue := v.Elem()
 		if !vValue.IsValid() {
 			return
 		}
 		t.travel(path, vValue)
 	case reflect.Interface:
+		fmt.Printf("travel interface")
 		/*
 			vValue := v.Elem()
 			copyValue := reflect.New(vValue.Type()).Elem()
@@ -35,8 +37,13 @@ func (t *Travel) travel(path string, v reflect.Value) {
 			copy.Set(copyValue)
 		*/
 	case reflect.Struct:
+		fmt.Printf("travel strcut")
 		for i := 0; i < v.NumField(); i += 1 {
-			t.travel(path, v.Field(i))
+			if !v.Field(i).IsValid() {
+				continue
+			}
+			tag := extractTag(v.Type().Field(i).Tag.Get(fieldTagName))
+			t.travel(path+"."+tag.Name, v.Field(i))
 		}
 	case reflect.Slice:
 		for i := 0; i < v.Len(); i += 1 {
@@ -56,6 +63,7 @@ func (t *Travel) travel(path string, v reflect.Value) {
 		// TODO get path
 		t.handle(path, v)
 	default:
+		fmt.Printf("default set value %#v\n", v)
 		//copy.Set(v)
 	}
 }

--- a/travel.go
+++ b/travel.go
@@ -1,0 +1,61 @@
+package configo
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type TravelHandle func(path string, v reflect.Value)
+
+type Travel struct {
+	handle TravelHandle
+}
+
+func NewTravel(h TravelHandle) *Travel {
+	return &Travel{handle: h}
+}
+
+func (t *Travel) Travel(obj interface{}) {
+	t.travel("", reflect.ValueOf(obj))
+}
+
+func (t *Travel) travel(path string, v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Ptr:
+		vValue := v.Elem()
+		if !vValue.IsValid() {
+			return
+		}
+		t.travel(path, vValue)
+	case reflect.Interface:
+		/*
+			vValue := v.Elem()
+			copyValue := reflect.New(vValue.Type()).Elem()
+			travel(copyValue, vValue)
+			copy.Set(copyValue)
+		*/
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i += 1 {
+			t.travel(path, v.Field(i))
+		}
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i += 1 {
+			p := fmt.Sprintf("%s.%d.", path, i)
+			t.travel(p, v.Index(i))
+		}
+	case reflect.Map:
+		/*
+			for _, key := range v.MapKeys() {
+				vValue := v.MapIndex(key)
+				copyValue := reflect.New(vValue.Type()).Elem()
+				t.travel(copyValue, vValue)
+				copy.SetMapIndex(key, copyValue)
+			}
+		*/
+	case reflect.String:
+		// TODO get path
+		t.handle(path, v)
+	default:
+		//copy.Set(v)
+	}
+}

--- a/travel.go
+++ b/travel.go
@@ -42,11 +42,14 @@ func (t *Travel) travel(path string, v reflect.Value) {
 			t.travel(p, v.Field(i))
 		}
 	case reflect.Slice, reflect.Array:
+		// handle slice & array as a whole
+		t.handle(path, v)
 		for i := 0; i < v.Len(); i++ {
 			p := fmt.Sprintf("%d", i)
 			if len(path) > 0 {
 				p = path + "." + p
 			}
+			// handle every element
 			t.travel(p, v.Index(i))
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/travel.go
+++ b/travel.go
@@ -3,9 +3,11 @@ package configo
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/shafreeck/toml"
 )
 
-type TravelHandle func(path string, v reflect.Value)
+type TravelHandle func(path string, tag *toml.CfgTag, v reflect.Value)
 
 type Travel struct {
 	handle TravelHandle
@@ -16,41 +18,45 @@ func NewTravel(h TravelHandle) *Travel {
 }
 
 func (t *Travel) Travel(obj interface{}) {
-	t.travel("", reflect.ValueOf(obj))
+	t.travel("", nil, reflect.ValueOf(obj))
 }
 
-func (t *Travel) travel(path string, v reflect.Value) {
+func (t *Travel) travel(path string, tag *toml.CfgTag, v reflect.Value) {
 	switch v.Kind() {
 	case reflect.Ptr:
 		vValue := v.Elem()
 		if !vValue.IsValid() {
 			return
 		}
-		t.travel(path, vValue)
+		t.travel(path, tag, vValue)
 	case reflect.Interface:
 		vValue := v.Elem()
 		if !vValue.IsValid() {
 			return
 		}
-		t.travel(path, vValue)
+		t.travel(path, tag, vValue)
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i += 1 {
 			if !v.Field(i).IsValid() {
 				continue
 			}
-			p := getPath(path, v.Type().Field(i))
-			t.travel(p, v.Field(i))
+			tag := extractTag(v.Type().Field(i).Tag.Get(fieldTagName))
+			p := tag.Name
+			if len(path) > 0 {
+				p = path + "." + tag.Name
+			}
+			t.travel(p, tag, v.Field(i))
 		}
 	case reflect.Slice, reflect.Array:
 		// handle slice & array as a whole
-		t.handle(path, v)
+		t.handle(path, tag, v)
 		for i := 0; i < v.Len(); i++ {
 			p := fmt.Sprintf("%d", i)
 			if len(path) > 0 {
 				p = path + "." + p
 			}
 			// handle every element
-			t.travel(p, v.Index(i))
+			t.travel(p, tag, v.Index(i))
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		fallthrough
@@ -61,16 +67,8 @@ func (t *Travel) travel(path string, v reflect.Value) {
 	case reflect.Bool:
 		fallthrough
 	case reflect.String:
-		t.handle(path, v)
+		t.handle(path, tag, v)
 	default:
 		panic(fmt.Sprintf("config file use unsupport type. %v", v.Type()))
 	}
-}
-
-func getPath(prefix string, f reflect.StructField) string {
-	tag := extractTag(f.Tag.Get(fieldTagName))
-	if len(prefix) == 0 {
-		return tag.Name
-	}
-	return prefix + "." + tag.Name
 }

--- a/travel_test.go
+++ b/travel_test.go
@@ -1,9 +1,9 @@
 package configo
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,14 +25,86 @@ func TestTravel_Travel(t *testing.T) {
 				"name": "name-value",
 			},
 		},
+		{
+			name: "test int,float,bool",
+			obj: struct {
+				name  string  `cfg:"name;;;user name"`
+				age   int     `cfg:"age;;;user age"`
+				score float64 `cfg:"score;;;user score"`
+				sex   bool    `cfg:"sex;;;user sex"`
+			}{
+				name:  "user-name",
+				age:   18,
+				score: 60.1,
+				sex:   true,
+			},
+			want: map[string]interface{}{
+				"name":  "user-name",
+				"age":   18,
+				"score": 60.1,
+				"sex":   true,
+			},
+		},
+		{
+			name: "test slice",
+			obj: struct {
+				Cluster []string `cfg:"cluster;;;the address of redis cluster"`
+			}{
+				Cluster: []string{"127.0.0.1:6379", "127.0.0.1:7379"},
+			},
+			want: map[string]interface{}{
+				"cluster.0": "127.0.0.1:6379",
+				"cluster.1": "127.0.0.1:7379",
+			},
+		},
+		{
+			name: "test array",
+			obj: struct {
+				Cluster [2]string `cfg:"cluster;;;the address of redis cluster"`
+			}{
+				Cluster: [2]string{"127.0.0.1:6379", "127.0.0.1:7379"},
+			},
+			want: map[string]interface{}{
+				"cluster.0": "127.0.0.1:6379",
+				"cluster.1": "127.0.0.1:7379",
+			},
+		},
+		{
+			name: "test time duration",
+			obj: struct {
+				Timeout time.Duration `cfg:"timeout;10s;;time out"`
+			}{
+				Timeout: 3 * time.Second,
+			},
+			want: map[string]interface{}{
+				"timeout": 3 * time.Second,
+			},
+		},
+		{
+			name: "test struct in struct",
+			obj: struct {
+				nest struct {
+					Timeout time.Duration `cfg:"timeout;10s;;time out"`
+				} `cfg:"nest;;;nest struct"`
+			}{
+				nest: struct {
+					Timeout time.Duration `cfg:"timeout;10s;;time out"`
+				}{
+					Timeout: 3 * time.Second,
+				},
+			},
+			want: map[string]interface{}{
+				"nest.timeout": 3 * time.Second,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handle := func(path string, v reflect.Value) {
-				fmt.Printf("paht=%s, v=%#v\n", path, v)
 				if w, ok := tt.want[path]; ok {
-					require.Equal(t, reflect.ValueOf(w), v)
+					wt := reflect.ValueOf(w)
+					testEqual(t, wt, v)
 					delete(tt.want, path)
 				}
 			}
@@ -43,5 +115,30 @@ func TestTravel_Travel(t *testing.T) {
 				require.FailNowf(t, "not get some path", "%#v", tt.want)
 			}
 		})
+	}
+}
+
+func testEqual(t *testing.T, want, get reflect.Value) {
+	require.Equal(t, want.Kind(), get.Kind())
+	switch get.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		require.Equal(t, want.Int(), get.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		require.Equal(t, want.Uint(), get.Uint())
+	case reflect.Uintptr:
+	case reflect.Float32, reflect.Float64:
+		require.Equal(t, want.Float(), get.Float())
+	case reflect.Bool:
+		require.Equal(t, want.Bool(), get.Bool())
+	case reflect.String:
+		require.Equal(t, want.String(), get.String())
+
+	case reflect.Slice, reflect.Array:
+		require.Equal(t, want.Len(), get.Len())
+		for i := 0; i < want.Len(); i++ {
+			testEqual(t, want.Index(i), get.Index(i))
+		}
+	default:
+		t.Fatalf("uset type %v", get.Kind())
 	}
 }

--- a/travel_test.go
+++ b/travel_test.go
@@ -1,0 +1,37 @@
+package configo
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestTravel_Travel(t *testing.T) {
+	tests := []struct {
+		name   string
+		obj    interface{}
+		handle TravelHandle
+	}{
+		{
+			name: "test string",
+			obj: struct {
+				name string `cfg:"name;;;user name"`
+			}{
+				name: "name",
+			},
+			want: map[string]reflect.Vlaue{
+				"name": a,
+			},
+			handle: func(path string, v reflect.Value) {
+				fmt.Printf("paht=%s, v=%#v\n", path, v)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := NewTravel(tt.handle)
+			tr.Travel(tt.obj)
+		})
+	}
+}

--- a/travel_test.go
+++ b/travel_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shafreeck/toml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,7 +104,7 @@ func TestTravel_Travel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handle := func(path string, v reflect.Value) {
+			handle := func(path string, tag *toml.CfgTag, v reflect.Value) {
 				if w, ok := tt.want[path]; ok {
 					wt := reflect.ValueOf(w)
 					testEqual(t, wt, v)

--- a/travel_test.go
+++ b/travel_test.go
@@ -53,6 +53,7 @@ func TestTravel_Travel(t *testing.T) {
 				Cluster: []string{"127.0.0.1:6379", "127.0.0.1:7379"},
 			},
 			want: map[string]interface{}{
+				"cluster":   []string{"127.0.0.1:6379", "127.0.0.1:7379"},
 				"cluster.0": "127.0.0.1:6379",
 				"cluster.1": "127.0.0.1:7379",
 			},
@@ -65,6 +66,7 @@ func TestTravel_Travel(t *testing.T) {
 				Cluster: [2]string{"127.0.0.1:6379", "127.0.0.1:7379"},
 			},
 			want: map[string]interface{}{
+				"cluster":   [2]string{"127.0.0.1:6379", "127.0.0.1:7379"},
 				"cluster.0": "127.0.0.1:6379",
 				"cluster.1": "127.0.0.1:7379",
 			},
@@ -106,6 +108,8 @@ func TestTravel_Travel(t *testing.T) {
 					wt := reflect.ValueOf(w)
 					testEqual(t, wt, v)
 					delete(tt.want, path)
+				} else {
+					require.FailNowf(t, "unknow path", "path=%s, v=%v", path, v)
 				}
 			}
 			tr := NewTravel(handle)
@@ -119,7 +123,7 @@ func TestTravel_Travel(t *testing.T) {
 }
 
 func testEqual(t *testing.T, want, get reflect.Value) {
-	require.Equal(t, want.Kind(), get.Kind())
+	require.Equal(t, want.Kind(), get.Kind(), "data kind not same")
 	switch get.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		require.Equal(t, want.Int(), get.Int())

--- a/travel_test.go
+++ b/travel_test.go
@@ -4,34 +4,44 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTravel_Travel(t *testing.T) {
 	tests := []struct {
-		name   string
-		obj    interface{}
-		handle TravelHandle
+		name string
+		obj  interface{}
+		want map[string]interface{}
 	}{
 		{
 			name: "test string",
 			obj: struct {
 				name string `cfg:"name;;;user name"`
 			}{
-				name: "name",
+				name: "name-value",
 			},
-			want: map[string]reflect.Vlaue{
-				"name": a,
-			},
-			handle: func(path string, v reflect.Value) {
-				fmt.Printf("paht=%s, v=%#v\n", path, v)
+			want: map[string]interface{}{
+				"name": "name-value",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tr := NewTravel(tt.handle)
+			handle := func(path string, v reflect.Value) {
+				fmt.Printf("paht=%s, v=%#v\n", path, v)
+				if w, ok := tt.want[path]; ok {
+					require.Equal(t, reflect.ValueOf(w), v)
+					delete(tt.want, path)
+				}
+			}
+			tr := NewTravel(handle)
 			tr.Travel(tt.obj)
+
+			if len(tt.want) > 0 {
+				require.FailNowf(t, "not get some path", "%#v", tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
通过在`flag.Parse()` 之前调用 `configo.AddFlags()` 方法，即可实现将配置文件中的参数添加到flag中，从而可以通过命令行设置配置文件参数。